### PR TITLE
feat: add identity verification with challenge-response

### DIFF
--- a/bin/agentchat.js
+++ b/bin/agentchat.js
@@ -508,6 +508,39 @@ program
     }
   });
 
+// Verify agent identity command
+program
+  .command('verify <server> <agent>')
+  .description('Verify another agent\'s identity via challenge-response')
+  .option('-i, --identity <file>', 'Path to identity file (required)', DEFAULT_IDENTITY_PATH)
+  .action(async (server, agent, options) => {
+    try {
+      const client = new AgentChatClient({ server, identity: options.identity });
+      await client.connect();
+
+      console.log(`Verifying identity of ${agent}...`);
+
+      const result = await client.verify(agent);
+
+      if (result.verified) {
+        console.log('Identity verified!');
+        console.log(`  Agent: ${result.agent}`);
+        console.log(`  Public Key:`);
+        console.log(result.pubkey.split('\n').map(line => `    ${line}`).join('\n'));
+      } else {
+        console.log('Verification failed!');
+        console.log(`  Target: ${result.target}`);
+        console.log(`  Reason: ${result.reason}`);
+      }
+
+      client.disconnect();
+      process.exit(result.verified ? 0 : 1);
+    } catch (err) {
+      console.error('Error:', err.message);
+      process.exit(1);
+    }
+  });
+
 // Identity management command
 program
   .command('identity')

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -60,8 +60,8 @@ Help agents find servers, each other, and verify identity.
 - [x] Server health checks and status
 - [x] Agent presence/availability status
 - [ ] **skills.md standard**: Publish capabilities + public key on MoltX/Moltbook
-- [ ] **Identity verification**: `VERIFY_REQUEST` / `VERIFY_RESPONSE` message types
-- [ ] Challenge-response flow: request signed nonce, verify against published key
+- [x] **Identity verification**: `VERIFY_REQUEST` / `VERIFY_RESPONSE` message types
+- [x] Challenge-response flow: request signed nonce, verify against published key
 - [ ] Key rotation: sign new key with old key for chain of custody
 - [ ] Key revocation: publish signed revocation notice
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -10,7 +10,8 @@ import {
   ServerMessageType,
   createMessage,
   serialize,
-  parse
+  parse,
+  generateNonce
 } from './protocol.js';
 import { Identity } from './identity.js';
 import {
@@ -532,6 +533,118 @@ export class AgentChatClient extends EventEmitter {
     });
   }
 
+  // ===== IDENTITY VERIFICATION METHODS =====
+
+  /**
+   * Request identity verification from another agent
+   * Sends a challenge nonce that the target must sign to prove they control their identity
+   * @param {string} target - Target agent to verify (@id)
+   * @returns {Promise<object>} Verification result with pubkey if successful
+   */
+  async verify(target) {
+    const targetAgent = target.startsWith('@') ? target : `@${target}`;
+    const nonce = generateNonce();
+
+    const msg = {
+      type: ClientMessageType.VERIFY_REQUEST,
+      target: targetAgent,
+      nonce
+    };
+
+    this._send(msg);
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.removeListener('verify_success', onSuccess);
+        this.removeListener('verify_failed', onFailed);
+        this.removeListener('error', onError);
+        reject(new Error('Verification timeout'));
+      }, 35000); // Slightly longer than server timeout
+
+      const onSuccess = (response) => {
+        if (response.agent === targetAgent || response.target === targetAgent) {
+          clearTimeout(timeout);
+          this.removeListener('verify_failed', onFailed);
+          this.removeListener('error', onError);
+          resolve({
+            verified: true,
+            agent: response.agent,
+            pubkey: response.pubkey,
+            request_id: response.request_id
+          });
+        }
+      };
+
+      const onFailed = (response) => {
+        if (response.target === targetAgent) {
+          clearTimeout(timeout);
+          this.removeListener('verify_success', onSuccess);
+          this.removeListener('error', onError);
+          resolve({
+            verified: false,
+            target: response.target,
+            reason: response.reason,
+            request_id: response.request_id
+          });
+        }
+      };
+
+      const onError = (err) => {
+        clearTimeout(timeout);
+        this.removeListener('verify_success', onSuccess);
+        this.removeListener('verify_failed', onFailed);
+        reject(new Error(err.message));
+      };
+
+      this.on('verify_success', onSuccess);
+      this.on('verify_failed', onFailed);
+      this.once('error', onError);
+    });
+  }
+
+  /**
+   * Respond to a verification request by signing the nonce
+   * This is typically called automatically when a VERIFY_REQUEST is received
+   * @param {string} requestId - The verification request ID
+   * @param {string} nonce - The nonce to sign
+   */
+  async respondToVerification(requestId, nonce) {
+    if (!this._identity || !this._identity.privkey) {
+      throw new Error('Responding to verification requires persistent identity.');
+    }
+
+    const sig = this._identity.sign(nonce);
+
+    const msg = {
+      type: ClientMessageType.VERIFY_RESPONSE,
+      request_id: requestId,
+      nonce,
+      sig
+    };
+
+    this._send(msg);
+  }
+
+  /**
+   * Enable automatic verification response
+   * When enabled, the client will automatically respond to VERIFY_REQUEST messages
+   * @param {boolean} enabled - Whether to enable auto-response
+   */
+  enableAutoVerification(enabled = true) {
+    if (enabled) {
+      this._autoVerifyHandler = (msg) => {
+        if (msg.request_id && msg.nonce && msg.from) {
+          this.respondToVerification(msg.request_id, msg.nonce)
+            .catch(err => this.emit('error', { message: `Auto-verification failed: ${err.message}` }));
+        }
+      };
+      this.on('verify_request', this._autoVerifyHandler);
+    } else if (this._autoVerifyHandler) {
+      this.removeListener('verify_request', this._autoVerifyHandler);
+      this._autoVerifyHandler = null;
+    }
+  }
+
   _send(msg) {
     if (this.ws && this.ws.readyState === WebSocket.OPEN) {
       this.ws.send(serialize(msg));
@@ -629,6 +742,23 @@ export class AgentChatClient extends EventEmitter {
       case ServerMessageType.SEARCH_RESULTS:
         this.emit('search_results', msg);
         this.emit('message', msg);
+        break;
+
+      // Identity verification messages
+      case ServerMessageType.VERIFY_REQUEST:
+        this.emit('verify_request', msg);
+        break;
+
+      case ServerMessageType.VERIFY_RESPONSE:
+        this.emit('verify_response', msg);
+        break;
+
+      case ServerMessageType.VERIFY_SUCCESS:
+        this.emit('verify_success', msg);
+        break;
+
+      case ServerMessageType.VERIFY_FAILED:
+        this.emit('verify_failed', msg);
         break;
     }
   }

--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -26,7 +26,10 @@ export const ClientMessageType = {
   REGISTER_SKILLS: 'REGISTER_SKILLS',
   SEARCH_SKILLS: 'SEARCH_SKILLS',
   // Presence message types
-  SET_PRESENCE: 'SET_PRESENCE'
+  SET_PRESENCE: 'SET_PRESENCE',
+  // Identity verification message types
+  VERIFY_REQUEST: 'VERIFY_REQUEST',
+  VERIFY_RESPONSE: 'VERIFY_RESPONSE'
 };
 
 // Server -> Client message types
@@ -51,7 +54,12 @@ export const ServerMessageType = {
   SKILLS_REGISTERED: 'SKILLS_REGISTERED',
   SEARCH_RESULTS: 'SEARCH_RESULTS',
   // Presence message types
-  PRESENCE_CHANGED: 'PRESENCE_CHANGED'
+  PRESENCE_CHANGED: 'PRESENCE_CHANGED',
+  // Identity verification message types
+  VERIFY_REQUEST: 'VERIFY_REQUEST',
+  VERIFY_RESPONSE: 'VERIFY_RESPONSE',
+  VERIFY_SUCCESS: 'VERIFY_SUCCESS',
+  VERIFY_FAILED: 'VERIFY_FAILED'
 };
 
 // Error codes
@@ -72,7 +80,11 @@ export const ErrorCode = {
   NOT_PROPOSAL_PARTY: 'NOT_PROPOSAL_PARTY',
   // Staking errors
   INSUFFICIENT_REPUTATION: 'INSUFFICIENT_REPUTATION',
-  INVALID_STAKE: 'INVALID_STAKE'
+  INVALID_STAKE: 'INVALID_STAKE',
+  // Verification errors
+  VERIFICATION_FAILED: 'VERIFICATION_FAILED',
+  VERIFICATION_EXPIRED: 'VERIFICATION_EXPIRED',
+  NO_PUBKEY: 'NO_PUBKEY'
 };
 
 // Presence status
@@ -367,6 +379,35 @@ export function validateClientMessage(raw) {
       }
       break;
 
+    case ClientMessageType.VERIFY_REQUEST:
+      // Verify request requires: target agent and nonce
+      if (!msg.target) {
+        return { valid: false, error: 'Missing target agent' };
+      }
+      if (!isAgent(msg.target)) {
+        return { valid: false, error: 'Target must be an agent (@id)' };
+      }
+      if (!msg.nonce || typeof msg.nonce !== 'string') {
+        return { valid: false, error: 'Missing or invalid nonce' };
+      }
+      if (msg.nonce.length < 16 || msg.nonce.length > 128) {
+        return { valid: false, error: 'Nonce must be 16-128 characters' };
+      }
+      break;
+
+    case ClientMessageType.VERIFY_RESPONSE:
+      // Verify response requires: request_id, nonce, and signature
+      if (!msg.request_id) {
+        return { valid: false, error: 'Missing request_id' };
+      }
+      if (!msg.nonce || typeof msg.nonce !== 'string') {
+        return { valid: false, error: 'Missing or invalid nonce' };
+      }
+      if (!msg.sig || typeof msg.sig !== 'string') {
+        return { valid: false, error: 'Missing or invalid signature' };
+      }
+      break;
+
     default:
       return { valid: false, error: `Unknown message type: ${msg.type}` };
   }
@@ -421,4 +462,22 @@ export function isProposalMessage(type) {
     ClientMessageType.COMPLETE,
     ClientMessageType.DISPUTE
   ].includes(type);
+}
+
+/**
+ * Generate a unique verification request ID
+ * Format: verify_<timestamp>_<random>
+ */
+export function generateVerifyId() {
+  const timestamp = Date.now().toString(36);
+  const random = crypto.randomBytes(4).toString('hex');
+  return `verify_${timestamp}_${random}`;
+}
+
+/**
+ * Generate a random nonce for identity verification
+ * Returns a 32-character hex string
+ */
+export function generateNonce() {
+  return crypto.randomBytes(16).toString('hex');
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -16,6 +16,7 @@ import {
   validateClientMessage,
   generateAgentId,
   generateProposalId,
+  generateVerifyId,
   serialize,
   isChannel,
   isAgent,
@@ -23,6 +24,7 @@ import {
   pubkeyToAgentId,
   isProposalMessage
 } from './protocol.js';
+import crypto from 'crypto';
 import { ProposalStore, formatProposal, formatProposalResponse } from './proposals.js';
 import { ReputationStore } from './reputation.js';
 import {
@@ -97,6 +99,10 @@ export class AgentChatServer {
         this.escrowHooks.on(event, handler);
       }
     }
+
+    // Pending verification requests: request_id -> { from, target, nonce, expires }
+    this.pendingVerifications = new Map();
+    this.verificationTimeoutMs = options.verificationTimeoutMs || 30000; // 30 seconds default
 
     this.wss = null;
     this.httpServer = null;
@@ -402,6 +408,13 @@ export class AgentChatServer {
       // Presence messages
       case ClientMessageType.SET_PRESENCE:
         this._handleSetPresence(ws, msg);
+        break;
+      // Identity verification messages
+      case ClientMessageType.VERIFY_REQUEST:
+        this._handleVerifyRequest(ws, msg);
+        break;
+      case ClientMessageType.VERIFY_RESPONSE:
+        this._handleVerifyResponse(ws, msg);
         break;
     }
   }
@@ -1213,6 +1226,155 @@ export class AgentChatServer {
     for (const channelName of agent.channels) {
       this._broadcast(channelName, presenceMsg);
     }
+  }
+
+  _handleVerifyRequest(ws, msg) {
+    const agent = this.agents.get(ws);
+    if (!agent) {
+      this._send(ws, createError(ErrorCode.AUTH_REQUIRED, 'Must IDENTIFY first'));
+      return;
+    }
+
+    // Find target agent
+    const targetId = msg.target.slice(1); // remove @
+    const targetWs = this.agentById.get(targetId);
+
+    if (!targetWs) {
+      this._send(ws, createError(ErrorCode.AGENT_NOT_FOUND, `Agent ${msg.target} not found`));
+      return;
+    }
+
+    const targetAgent = this.agents.get(targetWs);
+
+    // Target must have a pubkey for verification
+    if (!targetAgent.pubkey) {
+      this._send(ws, createError(ErrorCode.NO_PUBKEY, `Agent ${msg.target} has no persistent identity`));
+      return;
+    }
+
+    // Create verification request
+    const requestId = generateVerifyId();
+    const expires = Date.now() + this.verificationTimeoutMs;
+
+    this.pendingVerifications.set(requestId, {
+      from: `@${agent.id}`,
+      fromWs: ws,
+      target: msg.target,
+      targetPubkey: targetAgent.pubkey,
+      nonce: msg.nonce,
+      expires
+    });
+
+    // Set timeout to clean up expired requests
+    setTimeout(() => {
+      const request = this.pendingVerifications.get(requestId);
+      if (request) {
+        this.pendingVerifications.delete(requestId);
+        // Notify requester of timeout
+        if (request.fromWs.readyState === 1) {
+          this._send(request.fromWs, createMessage(ServerMessageType.VERIFY_FAILED, {
+            request_id: requestId,
+            target: request.target,
+            reason: 'Verification timed out'
+          }));
+        }
+      }
+    }, this.verificationTimeoutMs);
+
+    this._log('verify_request', { id: requestId, from: agent.id, target: targetId });
+
+    // Forward to target agent
+    this._send(targetWs, createMessage(ServerMessageType.VERIFY_REQUEST, {
+      request_id: requestId,
+      from: `@${agent.id}`,
+      nonce: msg.nonce
+    }));
+
+    // Acknowledge to requester
+    this._send(ws, createMessage(ServerMessageType.VERIFY_REQUEST, {
+      request_id: requestId,
+      target: msg.target,
+      status: 'pending'
+    }));
+  }
+
+  _handleVerifyResponse(ws, msg) {
+    const agent = this.agents.get(ws);
+    if (!agent) {
+      this._send(ws, createError(ErrorCode.AUTH_REQUIRED, 'Must IDENTIFY first'));
+      return;
+    }
+
+    // Must have identity to respond to verification
+    if (!agent.pubkey) {
+      this._send(ws, createError(ErrorCode.SIGNATURE_REQUIRED, 'Responding to verification requires persistent identity'));
+      return;
+    }
+
+    // Find the pending verification
+    const request = this.pendingVerifications.get(msg.request_id);
+    if (!request) {
+      this._send(ws, createError(ErrorCode.VERIFICATION_EXPIRED, 'Verification request not found or expired'));
+      return;
+    }
+
+    // Verify the responder is the target
+    if (request.target !== `@${agent.id}`) {
+      this._send(ws, createError(ErrorCode.INVALID_MSG, 'You are not the target of this verification'));
+      return;
+    }
+
+    // Verify the nonce matches
+    if (msg.nonce !== request.nonce) {
+      this._send(ws, createError(ErrorCode.INVALID_MSG, 'Nonce mismatch'));
+      return;
+    }
+
+    // Verify the signature
+    let verified = false;
+    try {
+      const keyObj = crypto.createPublicKey(request.targetPubkey);
+      verified = crypto.verify(
+        null,
+        Buffer.from(msg.nonce),
+        keyObj,
+        Buffer.from(msg.sig, 'base64')
+      );
+    } catch (err) {
+      this._log('verify_error', { request_id: msg.request_id, error: err.message });
+    }
+
+    // Clean up the pending request
+    this.pendingVerifications.delete(msg.request_id);
+
+    this._log('verify_response', {
+      request_id: msg.request_id,
+      from: agent.id,
+      verified
+    });
+
+    // Notify the original requester
+    if (request.fromWs.readyState === 1) {
+      if (verified) {
+        this._send(request.fromWs, createMessage(ServerMessageType.VERIFY_SUCCESS, {
+          request_id: msg.request_id,
+          agent: request.target,
+          pubkey: request.targetPubkey
+        }));
+      } else {
+        this._send(request.fromWs, createMessage(ServerMessageType.VERIFY_FAILED, {
+          request_id: msg.request_id,
+          target: request.target,
+          reason: 'Signature verification failed'
+        }));
+      }
+    }
+
+    // Notify the responder
+    this._send(ws, createMessage(verified ? ServerMessageType.VERIFY_SUCCESS : ServerMessageType.VERIFY_FAILED, {
+      request_id: msg.request_id,
+      verified
+    }));
   }
 
   _handleDisconnect(ws) {

--- a/test/verification.test.js
+++ b/test/verification.test.js
@@ -1,0 +1,281 @@
+/**
+ * Identity Verification Tests
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { AgentChatServer } from '../lib/server.js';
+import { AgentChatClient } from '../lib/client.js';
+import { Identity } from '../lib/identity.js';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+describe('Identity Verification', () => {
+  let server;
+  let testPort;
+  let testServer;
+  let tempDir;
+  let identity1;
+  let identity2;
+
+  before(async () => {
+    testPort = 16980 + Math.floor(Math.random() * 20);
+    testServer = `ws://localhost:${testPort}`;
+    server = new AgentChatServer({ port: testPort, logMessages: false });
+    server.start();
+
+    // Create temp directory for identity files
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentchat-verify-test-'));
+
+    // Create two identities for testing
+    identity1 = Identity.generate('verifier');
+    await identity1.save(path.join(tempDir, 'verifier.json'));
+
+    identity2 = Identity.generate('target');
+    await identity2.save(path.join(tempDir, 'target.json'));
+  });
+
+  after(() => {
+    server.stop();
+    // Clean up temp directory
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('can verify an agent with persistent identity', async () => {
+    const client1 = new AgentChatClient({
+      server: testServer,
+      identity: path.join(tempDir, 'verifier.json')
+    });
+    const client2 = new AgentChatClient({
+      server: testServer,
+      identity: path.join(tempDir, 'target.json')
+    });
+
+    await client1.connect();
+    await client2.connect();
+
+    // Enable auto-verification on client2
+    client2.enableAutoVerification(true);
+
+    // Verify client2 from client1
+    const result = await client1.verify(client2.agentId);
+
+    assert.strictEqual(result.verified, true);
+    assert.ok(result.pubkey, 'Should return pubkey');
+    assert.ok(result.pubkey.includes('PUBLIC KEY'), 'Pubkey should be PEM format');
+
+    client1.disconnect();
+    client2.disconnect();
+  });
+
+  it('verification fails for agent without pubkey', async () => {
+    const client1 = new AgentChatClient({
+      server: testServer,
+      identity: path.join(tempDir, 'verifier.json')
+    });
+    const client2 = new AgentChatClient({
+      server: testServer,
+      name: 'ephemeral-agent' // No identity
+    });
+
+    await client1.connect();
+    await client2.connect();
+
+    // Try to verify ephemeral agent - should fail
+    const errorPromise = new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Timeout')), 2000);
+      const handler = (msg) => {
+        clearTimeout(timeout);
+        client1.removeListener('error', handler);
+        resolve(msg);
+      };
+      client1.on('error', handler);
+    });
+
+    client1.sendRaw({
+      type: 'VERIFY_REQUEST',
+      target: client2.agentId,
+      nonce: 'test-nonce-12345678'
+    });
+
+    const errorMsg = await errorPromise;
+    assert.strictEqual(errorMsg.code, 'NO_PUBKEY');
+
+    client1.disconnect();
+    client2.disconnect();
+  });
+
+  it('verification fails for non-existent agent', async () => {
+    const client1 = new AgentChatClient({
+      server: testServer,
+      identity: path.join(tempDir, 'verifier.json')
+    });
+
+    await client1.connect();
+
+    const errorPromise = new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Timeout')), 2000);
+      const handler = (msg) => {
+        clearTimeout(timeout);
+        client1.removeListener('error', handler);
+        resolve(msg);
+      };
+      client1.on('error', handler);
+    });
+
+    client1.sendRaw({
+      type: 'VERIFY_REQUEST',
+      target: '@nonexistent',
+      nonce: 'test-nonce-12345678'
+    });
+
+    const errorMsg = await errorPromise;
+    assert.strictEqual(errorMsg.code, 'AGENT_NOT_FOUND');
+
+    client1.disconnect();
+  });
+
+  it('verification fails with invalid signature', async () => {
+    const client1 = new AgentChatClient({
+      server: testServer,
+      identity: path.join(tempDir, 'verifier.json')
+    });
+    const client2 = new AgentChatClient({
+      server: testServer,
+      identity: path.join(tempDir, 'target.json')
+    });
+
+    await client1.connect();
+    await client2.connect();
+
+    // Don't use auto-verification - manually respond with invalid signature
+    const requestPromise = new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Timeout')), 5000);
+      const handler = (msg) => {
+        if (msg.nonce && msg.request_id && msg.from) {
+          clearTimeout(timeout);
+          client2.removeListener('verify_request', handler);
+          resolve(msg);
+        }
+      };
+      client2.on('verify_request', handler);
+    });
+
+    // Start verification
+    const verifyPromise = client1.verify(client2.agentId);
+
+    // Wait for request on client2
+    const request = await requestPromise;
+
+    // Send invalid signature response
+    client2.sendRaw({
+      type: 'VERIFY_RESPONSE',
+      request_id: request.request_id,
+      nonce: request.nonce,
+      sig: 'invalid-signature-not-base64!'
+    });
+
+    // Should get verification failed result
+    const result = await verifyPromise;
+    assert.strictEqual(result.verified, false);
+    assert.ok(result.reason.includes('failed'), 'Should indicate failure reason');
+
+    client1.disconnect();
+    client2.disconnect();
+  });
+
+  it('requires authentication for verification requests', async () => {
+    const WebSocket = (await import('ws')).default;
+    const ws = new WebSocket(testServer);
+
+    await new Promise((resolve) => ws.on('open', resolve));
+
+    const errorPromise = new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Timeout')), 2000);
+      ws.on('message', (data) => {
+        const msg = JSON.parse(data.toString());
+        if (msg.type === 'ERROR') {
+          clearTimeout(timeout);
+          resolve(msg);
+        }
+      });
+    });
+
+    ws.send(JSON.stringify({
+      type: 'VERIFY_REQUEST',
+      target: '@someagent',
+      nonce: 'test-nonce-12345678'
+    }));
+
+    const errorMsg = await errorPromise;
+    assert.strictEqual(errorMsg.code, 'AUTH_REQUIRED');
+
+    ws.close();
+  });
+
+  it('can disable auto-verification', async () => {
+    const client = new AgentChatClient({
+      server: testServer,
+      identity: path.join(tempDir, 'target.json')
+    });
+
+    await client.connect();
+
+    // Enable then disable
+    client.enableAutoVerification(true);
+    assert.ok(client._autoVerifyHandler, 'Handler should be set');
+
+    client.enableAutoVerification(false);
+    assert.strictEqual(client._autoVerifyHandler, null, 'Handler should be removed');
+
+    client.disconnect();
+  });
+
+  it('handles verification timeout', async () => {
+    // Create a server with very short timeout for testing
+    const shortTimeoutServer = new AgentChatServer({
+      port: testPort + 1,
+      logMessages: false,
+      verificationTimeoutMs: 500 // 500ms timeout
+    });
+    shortTimeoutServer.start();
+
+    const client1 = new AgentChatClient({
+      server: `ws://localhost:${testPort + 1}`,
+      identity: path.join(tempDir, 'verifier.json')
+    });
+    const client2 = new AgentChatClient({
+      server: `ws://localhost:${testPort + 1}`,
+      identity: path.join(tempDir, 'target.json')
+    });
+
+    await client1.connect();
+    await client2.connect();
+
+    // Don't enable auto-verification - let it timeout
+    const failedPromise = new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Test timeout')), 2000);
+      const handler = (msg) => {
+        clearTimeout(timeout);
+        client1.removeListener('verify_failed', handler);
+        resolve(msg);
+      };
+      client1.on('verify_failed', handler);
+    });
+
+    // Send verification request
+    client1.sendRaw({
+      type: 'VERIFY_REQUEST',
+      target: client2.agentId,
+      nonce: 'test-nonce-12345678'
+    });
+
+    const failed = await failedPromise;
+    assert.ok(failed.reason.includes('timed out'), 'Should indicate timeout');
+
+    client1.disconnect();
+    client2.disconnect();
+    shortTimeoutServer.stop();
+  });
+});


### PR DESCRIPTION
- Add VERIFY_REQUEST/VERIFY_RESPONSE message types to protocol
- Add server handlers for verification with timeout and cleanup
- Add client methods: verify(), respondToVerification(), enableAutoVerification()
- Add CLI command: agentchat verify <server> <agent>
- Add 7 tests for verification functionality
- Update ROADMAP.md to mark identity verification complete

The verification flow:
1. Agent A sends VERIFY_REQUEST with random nonce to Agent B
2. Server relays request with unique request_id
3. Agent B signs nonce with their private key
4. Agent B sends VERIFY_RESPONSE with signature
5. Server verifies signature against Agent B's pubkey
6. Server notifies Agent A of success/failure with pubkey