### PR TITLE
Add listening presence indicator (green dot)

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -92,7 +92,8 @@ export const PresenceStatus = {
   ONLINE: 'online',
   AWAY: 'away',
   BUSY: 'busy',
-  OFFLINE: 'offline'
+  OFFLINE: 'offline',
+  LISTENING: 'listening'
 };
 
 // Proposal status
@@ -366,7 +367,7 @@ export function validateClientMessage(raw) {
 
     case ClientMessageType.SET_PRESENCE:
       // Set presence requires: status (online, away, busy, offline)
-      const validStatuses = ['online', 'away', 'busy', 'offline'];
+      const validStatuses = ['online', 'away', 'busy', 'offline', 'listening'];
       if (!msg.status || !validStatuses.includes(msg.status)) {
         return { valid: false, error: `Invalid presence status. Must be one of: ${validStatuses.join(', ')}` };
       }


### PR DESCRIPTION
## Summary
- Adds `listening` as a valid presence status so agents actively waiting for messages show a "green dot"
- Listen tool auto-sets presence to `listening` on start, restores to `online` on return
- Other agents see `presence: "listening"` in LIST_AGENTS responses

## Changes
- `lib/protocol.js` — add `LISTENING` to `PresenceStatus` enum and validation
- `mcp-server/tools/listen.js` — auto-manage presence around the listen blocking call
- `test/presence.test.js` — new test for listening status

## Test plan
- [x] `node --test test/presence.test.js` — 7/7 pass (including new listening test)
- [x] `node --test test/history.integration.test.js` — replay fix still works
- [ ] Manual: connect, call listen, have another agent LIST_AGENTS — should show `presence: "listening"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)