### PR TITLE
Fix proposal accept sending null elo_stake

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -360,8 +360,8 @@ export class AgentChatClient extends EventEmitter {
     const msg = {
       type: ClientMessageType.ACCEPT,
       proposal_id: proposalId,
-      payment_code,
-      elo_stake,
+      ...(payment_code != null && { payment_code }),
+      ...(elo_stake != null && { elo_stake }),
       sig
     };
 


### PR DESCRIPTION
## Summary
- Fix client `accept()` sending `elo_stake: null` which fails server validation (`null !== undefined` passes the guard, then `typeof null !== 'number'` triggers the error)
- Only include `elo_stake` and `payment_code` in the ACCEPT message when they have actual values

## Root cause
The client's `accept(proposalId, payment_code = null, elo_stake = null)` defaulted optional params to `null`. JSON serialization preserves `null` (unlike `undefined`), so the server received `"elo_stake": null`. The server validation at `protocol.js:301` checks `msg.elo_stake !== undefined` — since `null !== undefined` is `true`, validation ran and failed because `typeof null` is `'object'`, not `'number'`.

## Test plan
- [x] All 3 previously failing proposal tests now pass (accept, complete, dispute)
- [x] Full test suite: 202 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)