### PR TITLE
Add pre-auth rate limiting to prevent DoS

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -415,6 +415,33 @@ export class AgentChatServer {
   }
   
   _handleMessage(ws, data) {
+    // Per-connection rate limiting (applies before auth check)
+    const now = Date.now();
+    if (!ws._msgTimestamps) ws._msgTimestamps = [];
+
+    // Sliding window: keep only timestamps from last 10 seconds
+    ws._msgTimestamps = ws._msgTimestamps.filter(t => now - t < 10000);
+    ws._msgTimestamps.push(now);
+
+    const isIdentified = this.agents.has(ws);
+    // Pre-auth: max 10 messages per 10s window (enough for IDENTIFY + JOINs)
+    // Post-auth: max 60 messages per 10s window (existing MSG rate limit also applies)
+    const maxMessages = isIdentified ? 60 : 10;
+
+    if (ws._msgTimestamps.length > maxMessages) {
+      if (!isIdentified) {
+        this._log('pre_auth_rate_limit', {
+          ip: ws._realIp,
+          count: ws._msgTimestamps.length,
+          window: '10s'
+        });
+        ws.close(1008, 'Rate limit exceeded');
+        return;
+      }
+      this._send(ws, createError(ErrorCode.RATE_LIMITED, 'Too many messages'));
+      return;
+    }
+
     const { valid, msg, error } = validateClientMessage(data);
 
     if (!valid) {


### PR DESCRIPTION
## Summary
- Adds sliding window rate limiter in `_handleMessage` that applies **before** authentication check
- Pre-auth connections: max 10 messages per 10-second window (sufficient for IDENTIFY + JOIN flows), then disconnected with close code 1008
- Post-auth connections: max 60 messages per 10-second window (existing per-handler MSG rate limit also applies)
- Logs `pre_auth_rate_limit` events for monitoring

## Context
Found via `openpen ws-test` against the live server — the ws-rate check showed that pre-auth connections could send unlimited messages without any throttling, creating a DoS vector.

## Test plan
- [x] All 202 existing tests pass
- [ ] Run `openpen ws-test wss://agentchat-server.fly.dev` after deploy to verify rate limiting is enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)