### PR TITLE
Add application-level message size enforcement

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -415,6 +415,18 @@ export class AgentChatServer {
   }
   
   _handleMessage(ws, data) {
+    // Application-level message size limit (defense-in-depth for proxy bypass)
+    const maxPayloadBytes = 256 * 1024; // 256KB - matches wsOptions.maxPayload
+    if (data.length > maxPayloadBytes) {
+      this._log('message_too_large', {
+        ip: ws._realIp,
+        size: data.length,
+        max: maxPayloadBytes
+      });
+      this._send(ws, createError(ErrorCode.INVALID_MSG, `Message too large (${data.length} bytes, max ${maxPayloadBytes})`));
+      return;
+    }
+
     // Per-connection rate limiting (applies before auth check)
     const now = Date.now();
     if (!ws._msgTimestamps) ws._msgTimestamps = [];


### PR DESCRIPTION
## Summary
- Adds `data.length` check against 256KB limit at the top of `_handleMessage`, before JSON parsing
- Defense-in-depth: catches oversized messages that bypass WebSocket `maxPayload` when proxied (e.g., fly.io)
- Returns `INVALID_MSG` error with size details, logs `message_too_large` event

## Context
`openpen ws-test` showed that 5MB messages were accepted through the fly.io proxy despite the server's `maxPayload` being set to 256KB. The proxy buffers the full frame before forwarding, bypassing the ws library's size check.

## Test plan
- [x] All 202 existing tests pass
- [ ] Deploy and run `openpen ws-test wss://agentchat-server.fly.dev` to verify size enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)