### PR TITLE
Add MCP create_channel tool

### DIFF
--- a/mcp-server/tools/create-channel.js
+++ b/mcp-server/tools/create-channel.js
@@ -1,0 +1,58 @@
+/**
+ * AgentChat Create Channel Tool
+ * Handles creating new channels on the server
+ */
+
+import { z } from 'zod';
+import { client } from '../state.js';
+
+/**
+ * Register the create channel tool with the MCP server
+ */
+export function registerCreateChannelTool(server) {
+  server.tool(
+    'agentchat_create_channel',
+    'Create a new channel on the server',
+    {
+      channel: z.string().describe('Channel name (must start with #)'),
+      invite_only: z.boolean().optional().describe('Whether the channel is invite-only (default: false)'),
+    },
+    async ({ channel, invite_only }) => {
+      try {
+        if (!client || !client.connected) {
+          return {
+            content: [{ type: 'text', text: 'Not connected. Use agentchat_connect first.' }],
+            isError: true,
+          };
+        }
+
+        if (!channel.startsWith('#')) {
+          return {
+            content: [{ type: 'text', text: 'Channel name must start with #' }],
+            isError: true,
+          };
+        }
+
+        const result = await client.createChannel(channel, invite_only || false);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                channel: result.channel,
+                agents: result.agents,
+              }),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text', text: `Error creating channel: ${error.message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/mcp-server/tools/index.js
+++ b/mcp-server/tools/index.js
@@ -7,7 +7,8 @@
  *   agentchat_connect     - Connect to server
  *   agentchat_send        - Send messages
  *   agentchat_listen      - Receive messages
- *   agentchat_channels    - List channels
+ *   agentchat_channels       - List channels
+ *   agentchat_create_channel - Create a channel
  *   agentchat_daemon_*    - Background daemon
  *   agentchat_inbox       - Read daemon inbox
  *
@@ -29,6 +30,7 @@ import { registerConnectTool } from './connect.js';
 import { registerSendTool } from './send.js';
 import { registerListenTool } from './listen.js';
 import { registerChannelsTool } from './channels.js';
+import { registerCreateChannelTool } from './create-channel.js';
 import { registerDaemonTools } from './daemon.js';
 import { registerMarketplaceTools } from './marketplace/index.js';
 
@@ -41,6 +43,7 @@ export function registerAllTools(server) {
   registerSendTool(server);
   registerListenTool(server);
   registerChannelsTool(server);
+  registerCreateChannelTool(server);
   registerDaemonTools(server);
 
   // === MARKETPLACE TOOLS ===


### PR DESCRIPTION
## Summary
- Adds `agentchat_create_channel` MCP tool that wires `client.createChannel()` to MCP
- Accepts `channel` (string, must start with #) and optional `invite_only` (boolean)
- Follows existing tool patterns (send.js, channels.js)

## Test plan
- [ ] Connect to server via MCP, call `agentchat_create_channel` with `channel: "#tasks"`
- [ ] Verify channel appears in `agentchat_channels` list
- [ ] Verify sending messages to the new channel works
- [ ] Test error case: channel name without # prefix
- [ ] Test error case: not connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)