### PR TITLE
Add /nick command — SET_NICK + MCP tool

### DIFF
--- a/lib/protocol.ts
+++ b/lib/protocol.ts
@@ -47,6 +47,8 @@ export const ClientMessageType = {
   ADMIN_LIST: 'ADMIN_LIST' as const,
   // Challenge-response auth
   VERIFY_IDENTITY: 'VERIFY_IDENTITY' as const,
+  // Nick
+  SET_NICK: 'SET_NICK' as const,
 };
 
 export const ServerMessageType = {
@@ -80,6 +82,8 @@ export const ServerMessageType = {
   ADMIN_RESULT: 'ADMIN_RESULT' as const,
   // Challenge-response auth
   CHALLENGE: 'CHALLENGE' as const,
+  // Nick
+  NICK_CHANGED: 'NICK_CHANGED' as const,
 };
 
 export const ErrorCode = {
@@ -239,6 +243,7 @@ interface RawClientMessage {
   challenge_id?: string;
   signature?: string;
   timestamp?: number;
+  nick?: string;
 }
 
 /**
@@ -487,6 +492,18 @@ export function validateClientMessage(raw: string | RawClientMessage): Validatio
     case ClientMessageType.ADMIN_LIST:
       if (!msg.admin_key || typeof msg.admin_key !== 'string') {
         return { valid: false, error: 'Missing admin_key' };
+      }
+      break;
+
+    case ClientMessageType.SET_NICK:
+      if (!msg.nick || typeof msg.nick !== 'string') {
+        return { valid: false, error: 'Missing or invalid nick' };
+      }
+      if (msg.nick.length < 1 || msg.nick.length > 24) {
+        return { valid: false, error: 'Nick must be 1-24 characters' };
+      }
+      if (!/^[a-zA-Z0-9_-]+$/.test(msg.nick)) {
+        return { valid: false, error: 'Nick must contain only alphanumeric characters, hyphens, and underscores' };
       }
       break;
 

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -60,6 +60,9 @@ import {
   handleSetPresence,
 } from './server/handlers/presence.js';
 import {
+  handleSetNick,
+} from './server/handlers/nick.js';
+import {
   handleAdminApprove,
   handleAdminRevoke,
   handleAdminList,
@@ -753,6 +756,10 @@ export class AgentChatServer {
       // Challenge-response auth
       case ClientMessageType.VERIFY_IDENTITY:
         handleVerifyIdentity(this, ws, msg);
+        break;
+      // Nick
+      case ClientMessageType.SET_NICK:
+        handleSetNick(this, ws, msg);
         break;
       // Admin messages
       case ClientMessageType.ADMIN_APPROVE:

--- a/lib/server/handlers/nick.ts
+++ b/lib/server/handlers/nick.ts
@@ -1,0 +1,80 @@
+/**
+ * Nick Handler
+ * Handles SET_NICK command — allows agents to change their display name
+ */
+
+import type { WebSocket } from 'ws';
+import type { AgentChatServer } from '../../server.js';
+import type { SetNickMessage } from '../../types.js';
+import {
+  ServerMessageType,
+  ErrorCode,
+  createMessage,
+  createError,
+} from '../../protocol.js';
+
+// Extended WebSocket with custom properties
+interface ExtendedWebSocket extends WebSocket {
+  _connectedAt?: number;
+  _realIp?: string;
+  _userAgent?: string;
+  _lastNickChange?: number;
+}
+
+// Reserved nicks that cannot be claimed
+const RESERVED_NICKS = new Set([
+  'server', 'admin', 'system', 'root', 'moderator', 'mod',
+  'bot', 'agentchat', 'operator', 'shadow',
+]);
+
+// Rate limit: one nick change per 30 seconds
+const NICK_RATE_LIMIT_MS = 30000;
+
+/**
+ * Handle SET_NICK command
+ */
+export function handleSetNick(server: AgentChatServer, ws: ExtendedWebSocket, msg: SetNickMessage): void {
+  const agent = server.agents.get(ws);
+  if (!agent) {
+    server._send(ws, createError(ErrorCode.AUTH_REQUIRED, 'Must IDENTIFY first'));
+    return;
+  }
+
+  const nick = msg.nick.trim();
+
+  // Check reserved nicks
+  if (RESERVED_NICKS.has(nick.toLowerCase())) {
+    server._send(ws, createError(ErrorCode.INVALID_NAME, `Nick "${nick}" is reserved`));
+    return;
+  }
+
+  // Rate limit
+  const now = Date.now();
+  if (ws._lastNickChange && (now - ws._lastNickChange) < NICK_RATE_LIMIT_MS) {
+    const waitSec = Math.ceil((NICK_RATE_LIMIT_MS - (now - ws._lastNickChange)) / 1000);
+    server._send(ws, createError(ErrorCode.RATE_LIMITED, `Nick change rate limited. Try again in ${waitSec}s`));
+    return;
+  }
+
+  const oldNick = agent.name || `anon_${agent.id}`;
+
+  // Update name
+  agent.name = nick;
+  ws._lastNickChange = now;
+
+  server._log('nick_change', { agent: agent.id, old: oldNick, new: nick });
+
+  // Broadcast NICK_CHANGED to all channels the agent is in
+  const notification = createMessage(ServerMessageType.NICK_CHANGED, {
+    agent_id: `@${agent.id}`,
+    old_nick: oldNick,
+    new_nick: nick,
+  });
+
+  for (const channelName of agent.channels) {
+    server._broadcast(channelName, notification);
+  }
+
+  // Confirm to the sender
+  server._send(ws, notification);
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -28,7 +28,8 @@ export enum ClientMessageType {
   ADMIN_APPROVE = 'ADMIN_APPROVE',
   ADMIN_REVOKE = 'ADMIN_REVOKE',
   ADMIN_LIST = 'ADMIN_LIST',
-  VERIFY_IDENTITY = 'VERIFY_IDENTITY'
+  VERIFY_IDENTITY = 'VERIFY_IDENTITY',
+  SET_NICK = 'SET_NICK'
 }
 
 export enum ServerMessageType {
@@ -55,7 +56,8 @@ export enum ServerMessageType {
   VERIFY_SUCCESS = 'VERIFY_SUCCESS',
   VERIFY_FAILED = 'VERIFY_FAILED',
   ADMIN_RESULT = 'ADMIN_RESULT',
-  CHALLENGE = 'CHALLENGE'
+  CHALLENGE = 'CHALLENGE',
+  NICK_CHANGED = 'NICK_CHANGED'
 }
 
 export enum ErrorCode {
@@ -293,6 +295,11 @@ export interface VerifyIdentityMessage extends BaseMessage {
   timestamp: number;
 }
 
+export interface SetNickMessage extends BaseMessage {
+  type: ClientMessageType.SET_NICK;
+  nick: string;
+}
+
 export type ClientMessage =
   | IdentifyMessage
   | JoinMessage
@@ -316,7 +323,8 @@ export type ClientMessage =
   | AdminApproveMessage
   | AdminRevokeMessage
   | AdminListMessage
-  | VerifyIdentityMessage;
+  | VerifyIdentityMessage
+  | SetNickMessage;
 
 // ============ Server Messages ============
 
@@ -485,6 +493,13 @@ export interface ChallengeMessage extends BaseMessage {
   expires_at: number;
 }
 
+export interface NickChangedMessage extends BaseMessage {
+  type: ServerMessageType.NICK_CHANGED;
+  agent_id: string;
+  old_nick: string;
+  new_nick: string;
+}
+
 export interface AdminResultMessage extends BaseMessage {
   type: ServerMessageType.ADMIN_RESULT;
   action: string;
@@ -524,7 +539,8 @@ export type ServerMessage =
   | VerifySuccessMessage
   | VerifyFailedMessage
   | AdminResultMessage
-  | ChallengeMessage;
+  | ChallengeMessage
+  | NickChangedMessage;
 
 // ============ Validation Result ============
 

--- a/mcp-server/tools/index.js
+++ b/mcp-server/tools/index.js
@@ -32,6 +32,7 @@ import { registerListenTool } from './listen.js';
 import { registerChannelsTool } from './channels.js';
 import { registerCreateChannelTool } from './create-channel.js';
 import { registerDaemonTools } from './daemon.js';
+import { registerNickTool } from './nick.js';
 import { registerMarketplaceTools } from './marketplace/index.js';
 
 /**
@@ -44,6 +45,7 @@ export function registerAllTools(server) {
   registerListenTool(server);
   registerChannelsTool(server);
   registerCreateChannelTool(server);
+  registerNickTool(server);
   registerDaemonTools(server);
 
   // === MARKETPLACE TOOLS ===

--- a/mcp-server/tools/nick.js
+++ b/mcp-server/tools/nick.js
@@ -1,0 +1,69 @@
+/**
+ * AgentChat Nick Tool
+ * Handles changing agent display name (nick)
+ */
+
+import { z } from 'zod';
+import { client } from '../state.js';
+
+/**
+ * Register the nick tool with the MCP server
+ */
+export function registerNickTool(server) {
+  server.tool(
+    'agentchat_nick',
+    'Change your display name (nick). 1-24 chars, alphanumeric/hyphens/underscores only.',
+    {
+      nick: z.string().describe('New display name (1-24 chars, alphanumeric, hyphens, underscores)'),
+    },
+    async ({ nick }) => {
+      try {
+        if (!client || !client.connected) {
+          return {
+            content: [{ type: 'text', text: 'Not connected. Use agentchat_connect first.' }],
+            isError: true,
+          };
+        }
+
+        // Client-side validation
+        if (!nick || nick.length < 1 || nick.length > 24) {
+          return {
+            content: [{ type: 'text', text: 'Nick must be 1-24 characters' }],
+            isError: true,
+          };
+        }
+
+        if (!/^[a-zA-Z0-9_-]+$/.test(nick)) {
+          return {
+            content: [{ type: 'text', text: 'Nick must contain only alphanumeric characters, hyphens, and underscores' }],
+            isError: true,
+          };
+        }
+
+        // Send SET_NICK to server
+        client.ws.send(JSON.stringify({
+          type: 'SET_NICK',
+          nick,
+        }));
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                nick,
+                agent_id: client.agentId,
+              }),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text', text: `Error setting nick: ${error.message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- New `SET_NICK` client message type + `NICK_CHANGED` server broadcast
- Server handler with validation (1-24 chars, alphanumeric/hyphens/underscores), reserved nick protection, 30s rate limit
- `agentchat_nick` MCP tool for Claude Code integration
- NICK_CHANGED broadcast to all channels the agent is in

## Test plan
- [x] 230 existing tests pass, 0 failures
- [ ] Manual test: connect, set nick, verify NICK_CHANGED broadcast
- [ ] Test reserved nick rejection (server, admin, system)
- [ ] Test rate limit (30s cooldown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)