### PR TITLE
fix: Agentcourt review fixes — deterministic hashing, sig TODO

### DIFF
--- a/lib/disputes.ts
+++ b/lib/disputes.ts
@@ -297,10 +297,12 @@ export class DisputeStore {
     if (items.length > DISPUTE_CONSTANTS.MAX_EVIDENCE_ITEMS) return false;
     if (statement.length > DISPUTE_CONSTANTS.MAX_STATEMENT_CHARS) return false;
 
-    // Hash each item for integrity
+    // Hash each item for integrity (sorted keys for deterministic hashing)
     const hashedItems = items.map(item => ({
       ...item,
-      hash: crypto.createHash('sha256').update(JSON.stringify(item)).digest('hex'),
+      hash: crypto.createHash('sha256').update(
+        JSON.stringify(item, Object.keys(item).sort())
+      ).digest('hex'),
     }));
 
     const evidence = { items: hashedItems, statement, sig };

--- a/lib/server/handlers/disputes.ts
+++ b/lib/server/handlers/disputes.ts
@@ -1,6 +1,10 @@
 /**
  * Agentcourt Dispute Handlers
  * Server-side handlers for the panel-based dispute resolution system
+ *
+ * TODO: Signature verification — sigs are accepted but not cryptographically
+ * verified. This is a systemic issue (proposals don't verify either). Should be
+ * addressed holistically across proposals + disputes in a follow-up.
  */
 
 import type { WebSocket } from 'ws';
@@ -178,7 +182,7 @@ export async function handleDisputeReveal(server: AgentChatServer, ws: ExtendedW
     return;
   }
 
-  // Attempt reveal
+  // Attempt reveal (synchronous — phase check + transition is atomic in single-threaded Node.js)
   const revealed = server.disputes.reveal(dispute.id, msg.nonce);
   if (!revealed) {
     server._send(ws, createError(ErrorCode.DISPUTE_COMMITMENT_MISMATCH, 'Nonce does not match commitment'));


### PR DESCRIPTION
## Summary
Follow-up fixes from PR #23 review by @bmriau31:

- Use sorted-key JSON serialization for evidence item hashing (fixes non-deterministic key ordering)
- Add TODO for holistic signature verification across proposals + disputes
- Document that reveal phase transition is atomic in single-threaded Node.js

## Test plan
- [x] All 246 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)